### PR TITLE
Add VUS links to verification admin

### DIFF
--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -82,10 +82,12 @@ class VerificationAdmin(admin.ModelAdmin):
         return linebreaksbr("\n".join(find_school_names(obj.email)))
 
     def user_sets(self, obj):
-        users = set()
-        comments = []
+        verification_user_sets = []
 
         for vus in obj.user.verificationuserset_set.all():
+            users = set()
+            comments = []
+
             if vus.is_false_positive:
                 comments.append("False Positive VUS.")
 
@@ -96,9 +98,20 @@ class VerificationAdmin(admin.ModelAdmin):
                 if user != obj.user:
                     users.add(user)
 
+            verification_user_sets.append(
+                {
+                    "pk": vus.pk,
+                    "url": vus.get_absolute_url(),
+                    "users": users,
+                    "comments": comments,
+                }
+            )
+
         return render_to_string(
             "verifications/partials/verificationuserset_related_users_admin.html",
-            context={"users": users, "comments": comments},
+            context={
+                "verification_user_sets": verification_user_sets,
+            },
         )
 
     def user_info(self, instance):

--- a/app/grandchallenge/verifications/templates/verifications/partials/verificationuserset_related_users_admin.html
+++ b/app/grandchallenge/verifications/templates/verifications/partials/verificationuserset_related_users_admin.html
@@ -1,22 +1,26 @@
-<ul>
-    {% for user in users %}
-        <li>
-            {% if not user.is_active %}<s>{% endif %}
-            {% if user.verification %}
-                {% if user.verification.is_verified == True %}
-                    ✅
-                {% elif user.verification.is_verified == False %}
-                    ❌
-                {% else %}
-                    ?
+{% for vus in verification_user_sets %}
+<div>
+    <a href="{{ vus.url }}" target="_blank" rel="noopener noreferrer">VUS {{ vus.pk }}</a>
+    <ul>
+        {% for user in vus.users %}
+            <li>
+                {% if not user.is_active %}<s>{% endif %}
+                {% if user.verification %}
+                    {% if user.verification.is_verified == True %}
+                        ✅
+                    {% elif user.verification.is_verified == False %}
+                        ❌
+                    {% else %}
+                        ?
+                    {% endif %}
                 {% endif %}
-            {% endif %}
-            {{ user.username }}
-            {% if not user.is_active %}</s>{% endif %}
-        </li>
+                {{ user.username }}
+                {% if not user.is_active %}</s>{% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+    {% for comment in vus.comments %}
+        <p>{{ comment }}</p>
     {% endfor %}
-</ul>
-
-{% for comment in comments %}
-    <p>{{ comment }}</p>
+</div>
 {% endfor %}


### PR DESCRIPTION
Adds clickable links to the VerificationUserSet detail page in the verification admin list view.

- Display each VUS as a grouped block with its link, users and comments.
- Links open in a new tab for convenience.

<img width="1208" height="842" alt="image" src="https://github.com/user-attachments/assets/8269b0fd-b8d0-4452-83e9-2343aadb2f54" />

Related to https://github.com/DIAGNijmegen/rse-roadmap/issues/500
