### PR TITLE
Move utilization_duration methods out of `AmazonSageMakerBaseExecutor`

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_base.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_base.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import NamedTuple
 
 import boto3
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.utils.functional import cached_property
 
 from grandchallenge.components.backends.base import Executor
-from grandchallenge.components.backends.utils import ms_timestamp_to_datetime
 from grandchallenge.components.schemas import GPUTypeChoices
 
 logger = logging.getLogger(__name__)
@@ -291,18 +290,8 @@ INSTANCE_OPTIONS = [
 
 
 class AmazonSageMakerBaseExecutor(Executor, ABC):
-    @abstractmethod
-    def _get_start_time(self, *, event):
-        pass
-
-    @abstractmethod
-    def _get_end_time(self, *, event):
-        pass
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.__utilization_duration = None
 
         self.__sagemaker_client = None
         self.__logs_client = None
@@ -333,10 +322,6 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
                 region_name=settings.COMPONENTS_AMAZON_ECR_REGION,
             )
         return self.__cloudwatch_client
-
-    @property
-    def utilization_duration(self):
-        return self.__utilization_duration
 
     @cached_property
     def _instance_type(self):
@@ -374,14 +359,3 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
     def _max_memory_mb(self):
         # Reserve 1 GB for the system
         return (self._instance_type.memory - 1) * 1024
-
-    def _set_utilization_duration(self, *, event):
-        try:
-            started = ms_timestamp_to_datetime(
-                self._get_start_time(event=event)
-            )
-            stopped = ms_timestamp_to_datetime(self._get_end_time(event=event))
-            self.__utilization_duration = stopped - started
-        except TypeError:
-            logger.warning("Invalid start or end time, duration undetermined")
-            self.__utilization_duration = None

--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import NamedTuple
 from uuid import UUID
 
@@ -77,16 +77,13 @@ class AmazonSageMakerEndpointOrchestrator(AmazonSageMakerBaseExecutor):
             or settings.AWS_DEFAULT_REGION,
         )
 
-    def _get_start_time(self, *, event):
-        return int(
-            datetime.fromisoformat(event.get("receivedTime")).timestamp()
-            * 1000
-        )
+    @property
+    def utilization_duration(self):
+        raise NotImplementedError
 
-    def _get_end_time(self, *, event):
-        return int(
-            datetime.fromisoformat(event.get("eventTime")).timestamp() * 1000
-        )
+    @property
+    def compute_cost_euro_millicents(self):
+        raise NotImplementedError
 
     @property
     def runtime_setup_result_key(self):

--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -79,10 +79,12 @@ class AmazonSageMakerEndpointOrchestrator(AmazonSageMakerBaseExecutor):
 
     @property
     def utilization_duration(self):
+        # The duration is tracked on the Endpoint model.
         raise NotImplementedError
 
     @property
     def compute_cost_euro_millicents(self):
+        # The cost is calculated on the Endpoint model.
         raise NotImplementedError
 
     @property

--- a/app/grandchallenge/components/backends/amazon_sagemaker_training.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_training.py
@@ -370,7 +370,7 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.__utilization_duration = None
+        self._utilization_duration = None
 
     @property
     def _training_output_prefix(self):
@@ -387,7 +387,7 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
 
     @property
     def utilization_duration(self):
-        return self.__utilization_duration
+        return self._utilization_duration
 
     @property
     def compute_cost_euro_millicents(self):
@@ -505,10 +505,10 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
                 self._get_start_time(event=event)
             )
             stopped = ms_timestamp_to_datetime(self._get_end_time(event=event))
-            self.__utilization_duration = stopped - started
+            self._utilization_duration = stopped - started
         except TypeError:
             logger.warning("Invalid start or end time, duration undetermined")
-            self.__utilization_duration = None
+            self._utilization_duration = None
 
     def _create_job_boto(self):
         self._sagemaker_client.create_training_job(

--- a/app/grandchallenge/components/backends/amazon_sagemaker_training.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_training.py
@@ -364,6 +364,11 @@ class AmazonSageMakerTrainingLogsService:
 
 
 class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.__utilization_duration = None
+
     @property
     def _training_output_prefix(self):
         return safe_join("/training-outputs", *self.job_path_parts)
@@ -376,6 +381,10 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
             region=settings.COMPONENTS_AMAZON_ECR_REGION
             or settings.AWS_DEFAULT_REGION,
         )
+
+    @property
+    def utilization_duration(self):
+        return self.__utilization_duration
 
     @property
     def warm_pool_retained_billable_time_in_seconds(self):
@@ -475,6 +484,17 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
 
     def _get_end_time(self, *, event):
         return event.get("TrainingEndTime")
+
+    def _set_utilization_duration(self, *, event):
+        try:
+            started = ms_timestamp_to_datetime(
+                self._get_start_time(event=event)
+            )
+            stopped = ms_timestamp_to_datetime(self._get_end_time(event=event))
+            self.__utilization_duration = stopped - started
+        except TypeError:
+            logger.warning("Invalid start or end time, duration undetermined")
+            self.__utilization_duration = None
 
     def _create_job_boto(self):
         self._sagemaker_client.create_training_job(

--- a/app/grandchallenge/components/backends/amazon_sagemaker_training.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_training.py
@@ -20,7 +20,10 @@ from grandchallenge.components.backends.amazon_sagemaker_base import (
     INSTANCE_OPTIONS,
     AmazonSageMakerBaseExecutor,
 )
-from grandchallenge.components.backends.base import JobParams
+from grandchallenge.components.backends.base import (
+    JobParams,
+    duration_to_euro_millicents,
+)
 from grandchallenge.components.backends.exceptions import (
     ComponentException,
     RetryStep,
@@ -385,6 +388,17 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
     @property
     def utilization_duration(self):
         return self.__utilization_duration
+
+    @property
+    def compute_cost_euro_millicents(self):
+        utilization_duration = self.utilization_duration
+        if utilization_duration is None:
+            return None
+        else:
+            return duration_to_euro_millicents(
+                duration=utilization_duration,
+                usd_cents_per_hour=self.usd_cents_per_hour,
+            )
 
     @property
     def warm_pool_retained_billable_time_in_seconds(self):

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -419,6 +419,10 @@ class Executor(ABC):
     def utilization_duration(self): ...
 
     @property
+    @abstractmethod
+    def compute_cost_euro_millicents(self): ...
+
+    @property
     def exec_duration(self):
         return self._exec_duration
 
@@ -466,17 +470,6 @@ class Executor(ABC):
     @property
     def _max_memory_mb(self):
         return self._memory_limit * 1024
-
-    @property
-    def compute_cost_euro_millicents(self):
-        utilization_duration = self.utilization_duration
-        if utilization_duration is None:
-            return None
-        else:
-            return duration_to_euro_millicents(
-                duration=utilization_duration,
-                usd_cents_per_hour=self.usd_cents_per_hour,
-            )
 
     @property
     def job_path_parts(self):

--- a/app/tests/components_tests/resources/backends.py
+++ b/app/tests/components_tests/resources/backends.py
@@ -18,6 +18,7 @@ from grandchallenge.components.backends.base import (
     InferenceResult,
     JobParams,
     RuntimeSetupResult,
+    duration_to_euro_millicents,
 )
 from grandchallenge.components.backends.utils import UUID4_REGEX
 from grandchallenge.components.tasks import handle_event
@@ -185,6 +186,17 @@ class IOCopyExecutor(Executor):
     @property
     def utilization_duration(self):
         return now() - self.__start_time
+
+    @property
+    def compute_cost_euro_millicents(self):
+        utilization_duration = self.utilization_duration
+        if utilization_duration is None:
+            return None
+        else:
+            return duration_to_euro_millicents(
+                duration=utilization_duration,
+                usd_cents_per_hour=self.usd_cents_per_hour,
+            )
 
     @property
     def usd_cents_per_hour(self):

--- a/app/tests/utilization_tests/test_tasks.py
+++ b/app/tests/utilization_tests/test_tasks.py
@@ -27,6 +27,10 @@ class UtilizationExecutor(Executor):
     def utilization_duration(self):
         raise NotImplementedError
 
+    @property
+    def compute_cost_euro_millicents(self):
+        raise NotImplementedError
+
     def execute(self):
         raise NotImplementedError
 


### PR DESCRIPTION
Utilization and cost tracking is implemented differently for endpoints. By moving it out of `AmazonSageMakerBaseExecutor` to `AmazonSageMakerTrainingExecutor`, this difference is now explicit.

See #4817