### PR TITLE
Disallow creating verification with site email

### DIFF
--- a/app/grandchallenge/profiles/admin.py
+++ b/app/grandchallenge/profiles/admin.py
@@ -14,6 +14,7 @@ from grandchallenge.profiles.models import (
     UserProfileUserObjectPermission,
 )
 from grandchallenge.profiles.tasks import deactivate_user
+from grandchallenge.verifications.models import Verification
 
 
 class UserProfileInline(admin.StackedInline):
@@ -29,6 +30,18 @@ class UserProfileInline(admin.StackedInline):
 def deactivate_users(modeladmin, request, queryset):
     for user in queryset.filter(is_active=True):
         deactivate_user.execute_on_commit(user_pk=user.pk)
+
+
+@admin.action(
+    description="Create manual verification using current email",
+    permissions=("change",),
+)
+def create_manual_verification(modeladmin, request, queryset):
+    for user in queryset.exclude(verification__isnull=False):
+        Verification.objects.create(
+            user=user,
+            email=user.email,
+        )
 
 
 class UserProfileAdmin(UserAdmin):
@@ -54,7 +67,7 @@ class UserProfileAdmin(UserAdmin):
         "user_profile__notification_email_choice",
         "user_profile__country",
     )
-    actions = (deactivate_users,)
+    actions = (deactivate_users, create_manual_verification)
 
     @admin.display(boolean=True, description="User has 2FA enabled")
     def has_2fa_enabled(self, obj):

--- a/app/grandchallenge/verifications/models.py
+++ b/app/grandchallenge/verifications/models.py
@@ -60,6 +60,16 @@ class Verification(FieldChangeMixin, models.Model):
                     "please provide your work, corporate or institutional email."
                 )
 
+            site_domain = settings.SESSION_COOKIE_DOMAIN.lstrip(".")
+            email_domain = self.email.split("@")[1].lower()
+            if email_domain == site_domain or email_domain.endswith(
+                f".{site_domain}"
+            ):
+                raise ValidationError(
+                    "Email addresses on the site domain cannot be used "
+                    "for verification."
+                )
+
             if (
                 get_user_model()
                 .objects.filter(email__iexact=self.email)

--- a/app/tests/verification_tests/test_admin.py
+++ b/app/tests/verification_tests/test_admin.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth import get_user_model
 
 from grandchallenge.core.models import RequestBase
 from grandchallenge.core.utils.access_requests import (
@@ -139,3 +140,83 @@ def test_verify_users_and_accept_pending_requests(
     pr.refresh_from_db()
 
     assert pr.status == expected_request_status_with_verification
+
+
+@pytest.mark.django_db
+def test_create_manual_verification_admin_action(settings):
+    """Admin action creates a verification using the user's current email."""
+    from grandchallenge.profiles.admin import create_manual_verification
+    from grandchallenge.verifications.models import Verification
+
+    user = UserFactory(email="user@example.org")
+
+    create_manual_verification(
+        None,
+        None,
+        get_user_model().objects.filter(pk=user.pk),
+    )
+
+    verification = Verification.objects.get(user=user)
+    assert verification.email == "user@example.org"
+    assert verification.email_is_verified is True
+    assert verification.is_verified is False
+    assert verification.verified_at is None
+
+
+@pytest.mark.django_db
+def test_create_manual_verification_skips_existing(settings):
+    """Admin action skips users who already have a verification."""
+    from grandchallenge.profiles.admin import create_manual_verification
+    from grandchallenge.verifications.models import Verification
+
+    user = UserFactory(email="user@example.org")
+    VerificationFactory(user=user, email="old@example.org")
+
+    create_manual_verification(
+        None,
+        None,
+        get_user_model().objects.filter(pk=user.pk),
+    )
+
+    # Should not have changed the existing verification
+    verification = Verification.objects.get(user=user)
+    assert verification.email == "old@example.org"
+
+
+@pytest.mark.django_db
+def test_create_manual_verification_allows_site_domain(settings):
+    """Manual verification bypasses the site domain restriction."""
+    from grandchallenge.profiles.admin import create_manual_verification
+    from grandchallenge.verifications.models import Verification
+
+    site_domain = settings.SESSION_COOKIE_DOMAIN.lstrip(".")
+    user = UserFactory(email=f"admin@{site_domain}")
+
+    create_manual_verification(
+        None,
+        None,
+        get_user_model().objects.filter(pk=user.pk),
+    )
+
+    verification = Verification.objects.get(user=user)
+    assert verification.email == f"admin@{site_domain}"
+    assert verification.is_verified is False
+
+
+@pytest.mark.django_db
+def test_create_manual_verification_allows_free_email(settings):
+    """Manual verification bypasses the is_free restriction."""
+    from grandchallenge.profiles.admin import create_manual_verification
+    from grandchallenge.verifications.models import Verification
+
+    user = UserFactory(email="user@gmail.com")
+
+    create_manual_verification(
+        None,
+        None,
+        get_user_model().objects.filter(pk=user.pk),
+    )
+
+    verification = Verification.objects.get(user=user)
+    assert verification.email == "user@gmail.com"
+    assert verification.is_verified is False

--- a/app/tests/verification_tests/test_admin.py
+++ b/app/tests/verification_tests/test_admin.py
@@ -1,4 +1,5 @@
 import pytest
+from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 
 from grandchallenge.core.models import RequestBase
@@ -149,6 +150,9 @@ def test_create_manual_verification_admin_action(settings):
     from grandchallenge.verifications.models import Verification
 
     user = UserFactory(email="user@example.org")
+    EmailAddress.objects.create(
+        user=user, email="user@example.org", verified=True
+    )
 
     create_manual_verification(
         None,
@@ -159,7 +163,7 @@ def test_create_manual_verification_admin_action(settings):
     verification = Verification.objects.get(user=user)
     assert verification.email == "user@example.org"
     assert verification.email_is_verified is True
-    assert verification.is_verified is False
+    assert verification.is_verified is None
     assert verification.verified_at is None
 
 
@@ -200,7 +204,7 @@ def test_create_manual_verification_allows_site_domain(settings):
 
     verification = Verification.objects.get(user=user)
     assert verification.email == f"admin@{site_domain}"
-    assert verification.is_verified is False
+    assert verification.is_verified is None
 
 
 @pytest.mark.django_db
@@ -219,4 +223,4 @@ def test_create_manual_verification_allows_free_email(settings):
 
     verification = Verification.objects.get(user=user)
     assert verification.email == "user@gmail.com"
-    assert verification.is_verified is False
+    assert verification.is_verified is None

--- a/app/tests/verification_tests/test_models.py
+++ b/app/tests/verification_tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core import mail
+from django.core.exceptions import ValidationError
 
 from grandchallenge.core.models import RequestBase
 from grandchallenge.core.utils.access_requests import (
@@ -119,3 +120,31 @@ def test_accepting_pending_permission_requests_on_verification(
 
     assert pr_manual.status == RequestBase.PENDING
     assert pr.status == expected_request_status_with_verification
+
+
+@pytest.mark.django_db
+def test_verification_disallowed_for_site_domain_email(settings):
+    """Emails on the site domain cannot be used for verification."""
+    settings.SESSION_COOKIE_DOMAIN = ".example.com"
+    site_domain = "example.com"
+    user = UserFactory()
+
+    from grandchallenge.verifications.models import Verification
+
+    verification = Verification(user=user, email=f"test@{site_domain}")
+    with pytest.raises(ValidationError, match="site domain"):
+        verification.clean()
+
+
+@pytest.mark.django_db
+def test_verification_disallowed_for_site_subdomain_email(settings):
+    """Emails on subdomains of the site domain are also disallowed."""
+    settings.SESSION_COOKIE_DOMAIN = ".example.com"
+    site_domain = "example.com"
+    user = UserFactory()
+
+    from grandchallenge.verifications.models import Verification
+
+    verification = Verification(user=user, email=f"test@sub.{site_domain}")
+    with pytest.raises(ValidationError, match="site domain"):
+        verification.clean()


### PR DESCRIPTION
Also adds an admin action to create a verification for the current users email address, that can then be approved in the usual workflow.

See https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/902