### PR TITLE
Fix algorithm evaluation fixtures

### DIFF
--- a/scripts/algorithm_evaluation_fixtures.py
+++ b/scripts/algorithm_evaluation_fixtures.py
@@ -1,10 +1,8 @@
-import os
-from contextlib import contextmanager
-from pathlib import Path
+import hashlib
+import secrets
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.files.base import ContentFile
 from django.utils.timezone import now
 
 from grandchallenge.algorithms.models import (
@@ -24,6 +22,7 @@ from grandchallenge.evaluation.models import Method, Phase
 from grandchallenge.evaluation.utils import SubmissionKindChoices
 from grandchallenge.invoices.models import Invoice
 from grandchallenge.workstations.models import Workstation
+from scripts.development_fixtures import _uploaded_image_file
 
 
 def run():
@@ -140,10 +139,15 @@ def _create_challenge(
     p.submissions_limit_per_user_per_period = 10
     p.save()
 
-    m = Method(creator=creator, phase=p)
-
-    with _gc_demo_algorithm() as container:
-        m.image.save("algorithm_io.tar", container)
+    Method.objects.create(
+        creator=creator,
+        phase=p,
+        image_sha256=_get_random_sha256(),
+        import_status=Method.ImportStatusChoices.COMPLETED,
+        is_manifest_valid=True,
+        is_in_registry=True,
+        is_desired_version=True,
+    )
 
     return c
 
@@ -159,31 +163,16 @@ def _create_algorithm(*, creator, inputs, outputs, suffix):
     algorithm.interfaces.set([interface])
     algorithm.add_editor(creator)
 
-    algorithm_image = AlgorithmImage(creator=creator, algorithm=algorithm)
-
-    with _gc_demo_algorithm() as container:
-        algorithm_image.image.save("algorithm_io.tar", container)
-
-
-@contextmanager
-def _gc_demo_algorithm():
-    yield from _uploaded_file(
-        path=settings.SITE_ROOT
-        / "tests"
-        / "resources"
-        / "containers"
-        / "invoke"
-        / "invoke.tar.gz"
+    AlgorithmImage.objects.create(
+        creator=creator,
+        algorithm=algorithm,
+        image_sha256=_get_random_sha256(),
+        import_status=AlgorithmImage.ImportStatusChoices.COMPLETED,
+        is_manifest_valid=True,
+        is_in_registry=True,
+        is_desired_version=True,
     )
 
 
-@contextmanager
-def _uploaded_image_file():
-    path = Path(__file__).parent / "image10x10x10.mha"
-    yield from _uploaded_file(path=path)
-
-
-def _uploaded_file(*, path):
-    with open(os.path.join(settings.SITE_ROOT, path), "rb") as f:
-        with ContentFile(f.read()) as content:
-            yield content
+def _get_random_sha256():
+    return f"sha256:{hashlib.sha256(secrets.token_bytes(32)).hexdigest()}"

--- a/scripts/component_interface_value_fixtures.py
+++ b/scripts/component_interface_value_fixtures.py
@@ -4,7 +4,6 @@ from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 
 from grandchallenge.algorithms.models import AlgorithmImage, Job
-from grandchallenge.cases.models import Image, ImageFile
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
@@ -13,7 +12,7 @@ from grandchallenge.components.models import (
 from grandchallenge.core.fixtures import create_uploaded_image
 from grandchallenge.evaluation.models import Evaluation
 from grandchallenge.modalities.models import ImagingModality
-from scripts.algorithm_evaluation_fixtures import _uploaded_image_file
+from scripts.development_fixtures import _create_image
 
 
 def run():
@@ -206,23 +205,6 @@ def _create_civ_rich_algorithm_job(creator, interfaces):
             }
         ),
     )
-
-
-image_counter = 0
-
-
-def _create_image(**kwargs):
-    global image_counter
-
-    im = Image.objects.create(**kwargs)
-    im_file = ImageFile.objects.create(image=im)
-
-    with _uploaded_image_file() as f:
-        im_file.file.save(f"test_image_{image_counter}.mha", f)
-        image_counter += 1
-        im_file.save()
-
-    return im
 
 
 def _create_file_ci_instance(interface, name, content):

--- a/scripts/cost_fixtures.py
+++ b/scripts/cost_fixtures.py
@@ -26,7 +26,7 @@ from grandchallenge.evaluation.models import (
 )
 from grandchallenge.evaluation.utils import SubmissionKindChoices
 from grandchallenge.workstations.models import Workstation
-from scripts.algorithm_evaluation_fixtures import (
+from scripts.development_fixtures import (
     _gc_demo_algorithm,
     _uploaded_image_file,
 )

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -1,8 +1,11 @@
 import base64
 import itertools
 import logging
+import os
 import random
+from contextlib import contextmanager
 from datetime import timedelta
+from pathlib import Path
 
 from allauth.account.models import EmailAddress
 from django.conf import settings
@@ -25,6 +28,7 @@ from grandchallenge.algorithms.models import (
 )
 from grandchallenge.anatomy.models import BodyRegion, BodyStructure
 from grandchallenge.archives.models import Archive, ArchiveItem
+from grandchallenge.cases.models import Image, ImageFile
 from grandchallenge.challenges.models import Challenge, ChallengeSeries
 from grandchallenge.components.models import (
     ComponentInterface,
@@ -59,8 +63,6 @@ from grandchallenge.workstations.models import (
     Workstation,
     WorkstationImage,
 )
-from scripts.algorithm_evaluation_fixtures import _gc_demo_algorithm
-from scripts.component_interface_value_fixtures import _create_image
 
 logger = logging.getLogger(__name__)
 
@@ -555,3 +557,44 @@ def _create_user_tokens(users):
         out += f"\t{user} token is: {token}\n"
     out += f"{'*' * 80}\n"
     logger.debug(out)
+
+
+@contextmanager
+def _gc_demo_algorithm():
+    yield from _uploaded_file(
+        path=settings.SITE_ROOT
+        / "tests"
+        / "resources"
+        / "containers"
+        / "invoke"
+        / "invoke.tar.gz"
+    )
+
+
+def _uploaded_file(*, path):
+    with open(os.path.join(settings.SITE_ROOT, path), "rb") as f:
+        with ContentFile(f.read()) as content:
+            yield content
+
+
+@contextmanager
+def _uploaded_image_file():
+    path = Path(__file__).parent / "image10x10x10.mha"
+    yield from _uploaded_file(path=path)
+
+
+image_counter = 0
+
+
+def _create_image(**kwargs):
+    global image_counter
+
+    im = Image.objects.create(**kwargs)
+    im_file = ImageFile.objects.create(image=im)
+
+    with _uploaded_image_file() as f:
+        im_file.file.save(f"test_image_{image_counter}.mha", f)
+        image_counter += 1
+        im_file.save()
+
+    return im


### PR DESCRIPTION
Solution is to skip the container upload, this is not used during the evaluation process anyway. The other changes are just a reorganisation as this resulted in some methods not being used in the modules where they were implemented, and this resulted in some circular imports.

Closes #4963