### PR TITLE
Add remove option for images

### DIFF
--- a/app/grandchallenge/cases/form_fields.py
+++ b/app/grandchallenge/cases/form_fields.py
@@ -13,9 +13,9 @@ from grandchallenge.cases.widgets import (
     DICOMUploadWidget,
     DICOMUploadWithName,
     ImageSearchMultiWidget,
+    ImageSourceSelect,
 )
 from grandchallenge.components.models import SourceChoices
-from grandchallenge.components.widgets import SourceSelect
 from grandchallenge.core.guardian import filter_by_permission
 from grandchallenge.uploads.models import UserUpload
 
@@ -30,10 +30,11 @@ class ImageSourceChoices(TextChoices):
     UNDEFINED = SourceChoices.UNDEFINED, "Choose data source..."
     SEARCH = SourceChoices.SEARCH, "Select an existing image"
     UPLOAD = SourceChoices.UPLOAD, "Upload a new image"
+    REMOVE = SourceChoices.REMOVE, "Remove this image"
 
 
 class ImageSourceChoiceField(ChoiceField):
-    widget = SourceSelect(attrs={"class": "custom-select"})
+    widget = ImageSourceSelect(attrs={"class": "custom-select"})
 
     def __init__(
         self,
@@ -60,6 +61,13 @@ class ImageSourceChoiceField(ChoiceField):
                     SourceChoices.CURRENT.value,
                     current_socket_value.title,
                 ),
+            )
+        else:
+            choices.remove(
+                (
+                    ImageSourceChoices.REMOVE.value,
+                    ImageSourceChoices.REMOVE.label,
+                )
             )
 
         super().__init__(

--- a/app/grandchallenge/cases/templates/cases/warning_select.html
+++ b/app/grandchallenge/cases/templates/cases/warning_select.html
@@ -1,5 +1,5 @@
 {% include "django/forms/widgets/select.html" %}
 
 <div id="id_{{ widget.name }}_remove_warning" class="d-none alert alert-danger my-2" role="alert" style="width: fit-content;">
-    <i class="fas fa-exclamation-triangle mr-1"></i> If this file isn’t used anywhere else, removing it will <em>permanently</em> remove access to it.
+    <i class="fas fa-exclamation-triangle mr-1"></i> If this image isn’t used anywhere else, removing it will <em>permanently</em> remove access to it.
 </div>

--- a/app/grandchallenge/cases/widgets.py
+++ b/app/grandchallenge/cases/widgets.py
@@ -6,8 +6,13 @@ from django.forms import MultiWidget, TextInput
 from grandchallenge.components.widgets import (
     SearchSelect,
     SearchWidgetSuffixes,
+    SourceSelect,
 )
 from grandchallenge.uploads.widgets import DICOMUserUploadMultipleWidget
+
+
+class ImageSourceSelect(SourceSelect):
+    template_name = "cases/warning_select.html"
 
 
 class DICOMUploadWidgetSuffixes(StrEnum):

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2395,8 +2395,8 @@ class CIVData:
             self._upload_session = self._initial_value
         elif isinstance(self._initial_value, Image):
             self._image = self._initial_value
-        elif not self._initial_value:
-            self._image = None
+        elif self._initial_value == SourceChoices.REMOVE:
+            self._image = self._initial_value
         else:
             raise ValidationError(
                 f"Unknown data type {type(self._initial_value)} for interface {self._interface_slug}"
@@ -2603,7 +2603,9 @@ class CIVForObjectMixin:
     ):
         current_image = current_civ.image if current_civ else None
 
-        if image:
+        if image == SourceChoices.REMOVE:
+            self.remove_civ(civ=current_civ)
+        elif image:
             if current_image == image:
                 # Nothing to do.
                 return

--- a/app/tests/cases_tests/test_widget.py
+++ b/app/tests/cases_tests/test_widget.py
@@ -151,10 +151,12 @@ def test_image_source_select_prepopulated_value():
         ("CURRENT", "test_image"),
         ("SEARCH", "Select an existing image"),
         ("UPLOAD", "Upload a new image"),
+        ("REMOVE", "Remove this image"),
     ]
-    assert field.clean(SourceChoices.CURRENT.value) == im
+    assert field.clean(SourceChoices.CURRENT) == im
+    assert field.clean(SourceChoices.REMOVE) == SourceChoices.REMOVE
     with pytest.raises(ValidationError, match="This field is required."):
-        field.clean(ImageSourceChoices.UNDEFINED.value)
+        field.clean(ImageSourceChoices.UNDEFINED)
 
     field = ImageSourceChoiceField()
 
@@ -165,6 +167,8 @@ def test_image_source_select_prepopulated_value():
     ]
     assert field.current_socket_value is None
     with pytest.raises(ValidationError, match="Select a valid choice."):
-        field.clean(SourceChoices.CURRENT.value)
+        field.clean(SourceChoices.CURRENT)
+    with pytest.raises(ValidationError, match="Select a valid choice."):
+        field.clean(SourceChoices.REMOVE)
     with pytest.raises(ValidationError, match="This field is required."):
-        field.clean(ImageSourceChoices.UNDEFINED.value)
+        field.clean(ImageSourceChoices.UNDEFINED)

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -595,12 +595,8 @@ def test_display_set_update(
             client=client,
             reverse_kwargs={"pk": ds1.pk, "slug": rs.slug},
             data={
-                **get_interface_form_data(
-                    interface_slug=ci_img.slug,
-                    data=str(im2.pk),
-                    existing_data=True,
-                ),
-                f"{FlexibleWidgetPrefixes.CHOICE}{ci_json_file.slug}": SourceChoices.REMOVE.value,
+                f"{FlexibleWidgetPrefixes.CHOICE}{ci_img.slug}": SourceChoices.REMOVE,
+                f"{FlexibleWidgetPrefixes.CHOICE}{ci_json_file.slug}": SourceChoices.REMOVE,
                 "order": 12,
                 "title": "foobar_foobar",
             },
@@ -613,8 +609,8 @@ def test_display_set_update(
     )
 
     ds1.refresh_from_db()
-    assert ds1.values.count() == 1
-    assert ds1.values.filter(pk=civ_img_new.pk).exists()
+    assert ds1.values.count() == 0
+    assert not ds1.values.filter(pk=civ_img_new.pk).exists()
     assert not ds1.values.filter(pk=civ_json_file_new.pk).exists()
     assert not ds1.values.filter(interface=ci_json).exists()
 


### PR DESCRIPTION
Closes #3211

Removed images may become permanently inaccessible for the user. The widget displays a warning about that. 