### PR TITLE
Move inputs and outputs to Job and Evaluation models

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1182,6 +1182,43 @@ class Job(CIVForObjectMixin, ComponentJob):
         to=ComponentInterfaceValue,
         related_name="%(app_label)s_%(class)ss_as_output",
     )
+    exec_duration = models.DurationField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=(
+            "The duration of the execution, if measured. "
+            "Excludes data validation, container pulling, model downloading, "
+            "data downloading and data uploading times. "
+            "Includes model loading time, input data loading time, "
+            "processing time, output data writing time and "
+            "any delays from shared hardware issues."
+        ),
+    )
+    invoke_duration = models.DurationField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=(
+            "The duration of the invocation, if measured. "
+            "Excludes data validation, container pulling, model downloading, "
+            "data downloading and data uploading times. "
+            "Potentially excludes model loading time, depending on the "
+            "users implementation. "
+            "Includes input data loading time, "
+            "processing time, output data writing time and "
+            "any delays from shared hardware issues."
+        ),
+    )
+    input_prefixes = models.JSONField(
+        default=dict,
+        editable=False,
+        help_text=(
+            "Map of the ComponentInterfaceValue id to the path prefix to use "
+            "for this input, e.g. {'1': 'foo/bar/'} will place CIV 1 at "
+            "/input/foo/bar/<relative_path>"
+        ),
+    )
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL
     )

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1174,6 +1174,14 @@ class Job(CIVForObjectMixin, ComponentJob):
     algorithm_interface = models.ForeignKey(
         AlgorithmInterface, on_delete=models.PROTECT, null=True, blank=True
     )
+    inputs = models.ManyToManyField(
+        to=ComponentInterfaceValue,
+        related_name="%(app_label)s_%(class)ss_as_input",
+    )
+    outputs = models.ManyToManyField(
+        to=ComponentInterfaceValue,
+        related_name="%(app_label)s_%(class)ss_as_output",
+    )
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL
     )

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1693,45 +1693,8 @@ class ComponentJob(FieldChangeMixin, UUIDModel):
         choices=STATUS_CHOICES, default=PENDING, db_index=True
     )
     attempt = models.PositiveSmallIntegerField(editable=False, default=0)
-    exec_duration = models.DurationField(
-        null=True,
-        default=None,
-        editable=False,
-        help_text=(
-            "The duration of the execution, if measured. "
-            "Excludes data validation, container pulling, model downloading, "
-            "data downloading and data uploading times. "
-            "Includes model loading time, input data loading time, "
-            "processing time, output data writing time and "
-            "any delays from shared hardware issues."
-        ),
-    )
-    invoke_duration = models.DurationField(
-        null=True,
-        default=None,
-        editable=False,
-        help_text=(
-            "The duration of the invocation, if measured. "
-            "Excludes data validation, container pulling, model downloading, "
-            "data downloading and data uploading times. "
-            "Potentially excludes model loading time, depending on the "
-            "users implementation. "
-            "Includes input data loading time, "
-            "processing time, output data writing time and "
-            "any delays from shared hardware issues."
-        ),
-    )
     error_message = models.CharField(max_length=1024, default="")
     detailed_error_message = models.JSONField(blank=True, default=dict)
-    input_prefixes = models.JSONField(
-        default=dict,
-        editable=False,
-        help_text=(
-            "Map of the ComponentInterfaceValue id to the path prefix to use "
-            "for this input, e.g. {'1': 'foo/bar/'} will place CIV 1 at "
-            "/input/foo/bar/<relative_path>"
-        ),
-    )
     signing_key = models.BinaryField(
         max_length=32,
         default=secrets.token_bytes,

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1776,15 +1776,6 @@ class ComponentJob(FieldChangeMixin, UUIDModel):
         default=False, editable=False, help_text="Whether to use warm pools"
     )
 
-    inputs = models.ManyToManyField(
-        to=ComponentInterfaceValue,
-        related_name="%(app_label)s_%(class)ss_as_input",
-    )
-    outputs = models.ManyToManyField(
-        to=ComponentInterfaceValue,
-        related_name="%(app_label)s_%(class)ss_as_output",
-    )
-
     objects = ComponentJobManager.as_manager()
 
     @property

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -2179,6 +2179,44 @@ class Evaluation(CIVForObjectMixin, ComponentJob):
         related_name="%(app_label)s_%(class)ss_as_output",
     )
 
+    exec_duration = models.DurationField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=(
+            "The duration of the execution, if measured. "
+            "Excludes data validation, container pulling, model downloading, "
+            "data downloading and data uploading times. "
+            "Includes model loading time, input data loading time, "
+            "processing time, output data writing time and "
+            "any delays from shared hardware issues."
+        ),
+    )
+    invoke_duration = models.DurationField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=(
+            "The duration of the invocation, if measured. "
+            "Excludes data validation, container pulling, model downloading, "
+            "data downloading and data uploading times. "
+            "Potentially excludes model loading time, depending on the "
+            "users implementation. "
+            "Includes input data loading time, "
+            "processing time, output data writing time and "
+            "any delays from shared hardware issues."
+        ),
+    )
+    input_prefixes = models.JSONField(
+        default=dict,
+        editable=False,
+        help_text=(
+            "Map of the ComponentInterfaceValue id to the path prefix to use "
+            "for this input, e.g. {'1': 'foo/bar/'} will place CIV 1 at "
+            "/input/foo/bar/<relative_path>"
+        ),
+    )
+
     published = models.BooleanField(default=True, db_index=True)
     rank = models.PositiveIntegerField(
         default=0,

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -32,6 +32,7 @@ from grandchallenge.components.models import (
     CIVForObjectMixin,
     ComponentImage,
     ComponentInterface,
+    ComponentInterfaceValue,
     ComponentJob,
     ComponentJobManager,
     ImportStatusChoices,
@@ -2168,6 +2169,14 @@ class Evaluation(CIVForObjectMixin, ComponentJob):
     )
     ground_truth = models.ForeignKey(
         EvaluationGroundTruth, null=True, blank=True, on_delete=models.PROTECT
+    )
+    inputs = models.ManyToManyField(
+        to=ComponentInterfaceValue,
+        related_name="%(app_label)s_%(class)ss_as_input",
+    )
+    outputs = models.ManyToManyField(
+        to=ComponentInterfaceValue,
+        related_name="%(app_label)s_%(class)ss_as_output",
     )
 
     published = models.BooleanField(default=True, db_index=True)


### PR DESCRIPTION
This moves the `inputs` , `outputs` , `invoke_duration`, `exec_duration` and `input_prefixes` from  `ComponentJob` to `Evaluation` and `Job` in preparation for the batch jobs models. I confirmed that this is a no-op migration, hence no migration files. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/374