### PR TITLE
Update executor to provision a list of inference tasks

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -270,7 +270,9 @@ class AmazonSageMakerEndpointOrchestrator(AmazonSageMakerBaseExecutor):
             raise ValueError("Invalid endpoint status")
 
     def provision_invocation_input_data(self, *, input_civs):
-        super().provision(input_civs=input_civs, input_prefixes={})
+        super().provision(
+            task_specs=[self.build_inference_task_spec(input_civs=input_civs)]
+        )
 
     def invoke_endpoint(self, *, inference_id):
         self._sagemaker_runtime_client.invoke_endpoint_async(

--- a/app/grandchallenge/components/backends/amazon_sagemaker_training.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_training.py
@@ -60,6 +60,7 @@ class ModelChoices(TextChoices):
     # The labels must be in the form "<app_label>-<model_name>"
     ALGORITHMS_JOB = "A", "algorithms-job"
     EVALUATION_EVALUATION = "E", "evaluation-evaluation"
+    EVALUATION_BATCHJOB = "B", "evaluation-batchjob"
 
 
 class AmazonSageMakerTrainingLogsService:

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -9,6 +9,7 @@ import logging
 import os
 import secrets
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from datetime import timedelta
 from json import JSONDecodeError
 from math import ceil
@@ -82,6 +83,13 @@ class JobParams(NamedTuple):
 class CIVProvisioningTask(NamedTuple):
     key: str
     task: functools.partial
+
+
+class ProvisioningTask(NamedTuple):
+    pk: str
+    input_civs: Iterable[ComponentInterfaceValue]
+    input_prefixes: dict[str, str]
+    output_prefix: str
 
 
 def duration_to_euro_millicents(*, duration, usd_cents_per_hour):
@@ -377,14 +385,31 @@ class Executor(ABC):
         self.__s3_client = None
 
     def provision(self, *, input_civs, input_prefixes):
-        # We cannot run everything async as it requires database access.
-        # So first we gather the async tasks that need to be run,
-        # then execute them in the event loop for the current thread
-        # using a method wrapped in @async_to_sync.
-        provisioning_tasks = self._get_provisioning_tasks(
-            input_civs=input_civs, input_prefixes=input_prefixes
-        )
-        self._provision(tasks=provisioning_tasks)
+        tasks = [
+            ProvisioningTask(
+                pk=self._job_id,
+                input_civs=input_civs,
+                input_prefixes=input_prefixes,
+                output_prefix=self._io_prefix,
+            )
+        ]
+        self._provision(tasks=self._get_provisioning_tasks(tasks=tasks))
+
+    def provision_batch_job(self, *, batch_job):
+        tasks = [
+            ProvisioningTask(
+                pk=f"{self._job_id}-{task.pk}",
+                input_civs=task.inputs.prefetch_related(
+                    "interface", "image__files"
+                ).all(),
+                input_prefixes={},
+                output_prefix=self._output_prefix_for_task(
+                    task_pk=str(task.pk)
+                ),
+            )
+            for task in batch_job.tasks.all()
+        ]
+        self._provision(tasks=self._get_provisioning_tasks(tasks=tasks))
 
     @abstractmethod
     def execute(self): ...
@@ -484,6 +509,9 @@ class Executor(ABC):
     def _io_prefix(self):
         return safe_join("/io", *self.job_path_parts)
 
+    def _output_prefix_for_task(self, *, task_pk):
+        return safe_join(self._io_prefix, task_pk)
+
     @property
     def _invocation_prefix(self):
         return safe_join("/invocations", *self.job_path_parts)
@@ -582,31 +610,47 @@ class Executor(ABC):
                             )
                         )
 
-    def _get_provisioning_tasks(self, *, input_civs, input_prefixes):
+    def _get_provisioning_tasks(self, *, tasks):
         provisioning_tasks = []
-        invocation_inputs = []
+        inference_tasks = []
 
-        for civ in self._with_inputs_json(input_civs=input_civs):
-            for civ_provisioning_task in self._get_civ_provisioning_tasks(
-                civ=civ, input_prefixes=input_prefixes
-            ):
-                provisioning_tasks.append(civ_provisioning_task.task)
-                invocation_inputs.append(
-                    InferenceIO(
-                        relative_path=str(
-                            os.path.relpath(
-                                civ_provisioning_task.key, self._io_prefix
-                            )
-                        ),
-                        bucket_name=self._input_bucket_name,
-                        bucket_key=civ_provisioning_task.key,
-                        decompress=civ.decompress,
+        for task in tasks:
+            invocation_inputs = []
+
+            for civ in self._with_inputs_json(input_civs=task.input_civs):
+                for civ_provisioning_task in self._get_civ_provisioning_tasks(
+                    civ=civ,
+                    input_prefixes=task.input_prefixes,
+                    output_prefix=task.output_prefix,
+                ):
+                    provisioning_tasks.append(civ_provisioning_task.task)
+                    invocation_inputs.append(
+                        InferenceIO(
+                            relative_path=str(
+                                os.path.relpath(
+                                    civ_provisioning_task.key,
+                                    task.output_prefix,
+                                )
+                            ),
+                            bucket_name=self._input_bucket_name,
+                            bucket_key=civ_provisioning_task.key,
+                            decompress=civ.decompress,
+                        )
                     )
+
+            inference_tasks.append(
+                InferenceTask(
+                    pk=task.pk,
+                    inputs=invocation_inputs,
+                    output_bucket_name=self._output_bucket_name,
+                    output_prefix=task.output_prefix,
+                    timeout=self._time_limit,
                 )
+            )
 
         provisioning_tasks.append(
             self._get_create_invocation_json_task(
-                invocation_inputs=invocation_inputs
+                inference_tasks=inference_tasks
             ).task
         )
 
@@ -621,16 +665,17 @@ class Executor(ABC):
         *,
         civ,
         input_prefixes,
+        output_prefix,
         filename=None,
     ):
         relative_path = civ.interface.relative_path
 
         if str(civ.pk) in input_prefixes:
             key = safe_join(
-                self._io_prefix, input_prefixes[str(civ.pk)], relative_path
+                output_prefix, input_prefixes[str(civ.pk)], relative_path
             )
         else:
-            key = safe_join(self._io_prefix, relative_path)
+            key = safe_join(output_prefix, relative_path)
 
         if civ.interface.super_kind == civ.interface.SuperKind.IMAGE:
             if filename:
@@ -642,7 +687,9 @@ class Executor(ABC):
 
         return key
 
-    def _get_civ_provisioning_tasks(self, *, civ, input_prefixes):
+    def _get_civ_provisioning_tasks(
+        self, *, civ, input_prefixes, output_prefix
+    ):
         if civ.interface.super_kind == civ.interface.SuperKind.IMAGE:
             if civ.interface.is_dicom_image_kind:
                 session = boto3.Session(
@@ -660,6 +707,7 @@ class Executor(ABC):
                     key = self._get_key_for_target_relative_path(
                         civ=civ,
                         input_prefixes=input_prefixes,
+                        output_prefix=output_prefix,
                         filename=f"{instance_request.sop_instance_uid}.dcm",
                     )
 
@@ -677,6 +725,7 @@ class Executor(ABC):
                 key = self._get_key_for_target_relative_path(
                     civ=civ,
                     input_prefixes=input_prefixes,
+                    output_prefix=output_prefix,
                     filename=Path(image_file.name).name,
                 )
 
@@ -685,7 +734,9 @@ class Executor(ABC):
                 )
         elif civ.interface.super_kind == civ.interface.SuperKind.FILE:
             key = self._get_key_for_target_relative_path(
-                civ=civ, input_prefixes=input_prefixes
+                civ=civ,
+                input_prefixes=input_prefixes,
+                output_prefix=output_prefix,
             )
 
             yield self._get_copy_input_object_task(
@@ -693,7 +744,9 @@ class Executor(ABC):
             )
         elif civ.interface.super_kind == civ.interface.SuperKind.VALUE:
             key = self._get_key_for_target_relative_path(
-                civ=civ, input_prefixes=input_prefixes
+                civ=civ,
+                input_prefixes=input_prefixes,
+                output_prefix=output_prefix,
             )
 
             yield self._get_upload_input_content_task(
@@ -704,19 +757,15 @@ class Executor(ABC):
                 f"Unknown interface super kind: {civ.interface.super_kind}"
             )
 
-    def _get_create_invocation_json_task(self, *, invocation_inputs):
-        inference_task = InferenceTask(
-            pk=self._job_id,
-            inputs=invocation_inputs,
-            output_bucket_name=self._output_bucket_name,
-            output_prefix=self._io_prefix,
-            timeout=self._time_limit,
-        )
-
+    def _get_create_invocation_json_task(self, *, inference_tasks):
         if self._use_task_list:
-            content = to_json([inference_task])
+            content = to_json(inference_tasks)
         else:
-            content = to_json(inference_task)
+            if len(inference_tasks) != 1:
+                raise NotImplementedError(
+                    "A single task is required when not using a task list."
+                )
+            content = to_json(inference_tasks[0])
 
         return self._get_upload_input_content_task(
             content=content,

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -384,36 +384,27 @@ class Executor(ABC):
 
         self.__s3_client = None
 
-    def provision(self, *, input_civs, input_prefixes):
-        tasks = self._get_provisioning_tasks(
-            task_specs=[
-                InferenceTaskSpec(
-                    pk=self._job_id,
-                    input_civs=input_civs,
-                    input_prefixes=input_prefixes,
-                    output_prefix=self._io_prefix,
-                )
-            ]
-        )
+    def provision(self, *, task_specs):
+        # We cannot run everything async as it requires database access.
+        # So first we gather the async tasks that need to be run,
+        # then execute them in the event loop for the current thread
+        # using a method wrapped in @async_to_sync.
+        tasks = self._get_provisioning_tasks(task_specs=task_specs)
         self._provision(tasks=tasks)
 
-    def provision_batch_job(self, *, batch_job):
-        tasks = self._get_provisioning_tasks(
-            task_specs=[
-                InferenceTaskSpec(
-                    pk=f"{self._job_id}-{task.pk}",
-                    input_civs=task.inputs.all(),
-                    input_prefixes={},
-                    output_prefix=self._output_prefix_for_task(
-                        task_pk=str(task.pk)
-                    ),
-                )
-                for task in batch_job.tasks.prefetch_related(
-                    "inputs__interface", "inputs__image__files"
-                ).all()
-            ]
+    def build_inference_task_spec(
+        self, *, input_civs, input_prefixes=None, task_pk=None
+    ):
+        return InferenceTaskSpec(
+            pk=f"{self._job_id}-{task_pk}" if task_pk else self._job_id,
+            input_civs=input_civs,
+            input_prefixes=input_prefixes or {},
+            output_prefix=(
+                self._output_prefix_for_task(task_pk=task_pk)
+                if task_pk
+                else self._io_prefix
+            ),
         )
-        self._provision(tasks=tasks)
 
     @abstractmethod
     def execute(self): ...

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -402,15 +402,15 @@ class Executor(ABC):
             task_specs=[
                 InferenceTaskSpec(
                     pk=f"{self._job_id}-{task.pk}",
-                    input_civs=task.inputs.prefetch_related(
-                        "interface", "image__files"
-                    ).all(),
+                    input_civs=task.inputs.all(),
                     input_prefixes={},
                     output_prefix=self._output_prefix_for_task(
                         task_pk=str(task.pk)
                     ),
                 )
-                for task in batch_job.tasks.all()
+                for task in batch_job.tasks.prefetch_related(
+                    "inputs__interface", "inputs__image__files"
+                ).all()
             ]
         )
         self._provision(tasks=tasks)
@@ -766,10 +766,11 @@ class Executor(ABC):
             content = to_json(inference_tasks)
         else:
             if len(inference_tasks) != 1:
-                raise NotImplementedError(
+                raise ValueError(
                     "A single task is required when not using a task list."
                 )
-            content = to_json(inference_tasks[0])
+            else:
+                content = to_json(inference_tasks[0])
 
         return self._get_upload_input_content_task(
             content=content,

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -85,7 +85,7 @@ class CIVProvisioningTask(NamedTuple):
     task: functools.partial
 
 
-class ProvisioningTask(NamedTuple):
+class InferenceTaskSpec(NamedTuple):
     pk: str
     input_civs: Iterable[ComponentInterfaceValue]
     input_prefixes: dict[str, str]
@@ -385,31 +385,35 @@ class Executor(ABC):
         self.__s3_client = None
 
     def provision(self, *, input_civs, input_prefixes):
-        tasks = [
-            ProvisioningTask(
-                pk=self._job_id,
-                input_civs=input_civs,
-                input_prefixes=input_prefixes,
-                output_prefix=self._io_prefix,
-            )
-        ]
-        self._provision(tasks=self._get_provisioning_tasks(tasks=tasks))
+        tasks = self._get_provisioning_tasks(
+            task_specs=[
+                InferenceTaskSpec(
+                    pk=self._job_id,
+                    input_civs=input_civs,
+                    input_prefixes=input_prefixes,
+                    output_prefix=self._io_prefix,
+                )
+            ]
+        )
+        self._provision(tasks=tasks)
 
     def provision_batch_job(self, *, batch_job):
-        tasks = [
-            ProvisioningTask(
-                pk=f"{self._job_id}-{task.pk}",
-                input_civs=task.inputs.prefetch_related(
-                    "interface", "image__files"
-                ).all(),
-                input_prefixes={},
-                output_prefix=self._output_prefix_for_task(
-                    task_pk=str(task.pk)
-                ),
-            )
-            for task in batch_job.tasks.all()
-        ]
-        self._provision(tasks=self._get_provisioning_tasks(tasks=tasks))
+        tasks = self._get_provisioning_tasks(
+            task_specs=[
+                InferenceTaskSpec(
+                    pk=f"{self._job_id}-{task.pk}",
+                    input_civs=task.inputs.prefetch_related(
+                        "interface", "image__files"
+                    ).all(),
+                    input_prefixes={},
+                    output_prefix=self._output_prefix_for_task(
+                        task_pk=str(task.pk)
+                    ),
+                )
+                for task in batch_job.tasks.all()
+            ]
+        )
+        self._provision(tasks=tasks)
 
     @abstractmethod
     def execute(self): ...
@@ -610,18 +614,18 @@ class Executor(ABC):
                             )
                         )
 
-    def _get_provisioning_tasks(self, *, tasks):
+    def _get_provisioning_tasks(self, *, task_specs):
         provisioning_tasks = []
         inference_tasks = []
 
-        for task in tasks:
+        for task_spec in task_specs:
             invocation_inputs = []
 
-            for civ in self._with_inputs_json(input_civs=task.input_civs):
+            for civ in self._with_inputs_json(input_civs=task_spec.input_civs):
                 for civ_provisioning_task in self._get_civ_provisioning_tasks(
                     civ=civ,
-                    input_prefixes=task.input_prefixes,
-                    output_prefix=task.output_prefix,
+                    input_prefixes=task_spec.input_prefixes,
+                    output_prefix=task_spec.output_prefix,
                 ):
                     provisioning_tasks.append(civ_provisioning_task.task)
                     invocation_inputs.append(
@@ -629,7 +633,7 @@ class Executor(ABC):
                             relative_path=str(
                                 os.path.relpath(
                                     civ_provisioning_task.key,
-                                    task.output_prefix,
+                                    task_spec.output_prefix,
                                 )
                             ),
                             bucket_name=self._input_bucket_name,
@@ -640,10 +644,10 @@ class Executor(ABC):
 
             inference_tasks.append(
                 InferenceTask(
-                    pk=task.pk,
+                    pk=task_spec.pk,
                     inputs=invocation_inputs,
                     output_bucket_name=self._output_bucket_name,
-                    output_prefix=task.output_prefix,
+                    output_prefix=task_spec.output_prefix,
                     timeout=self._time_limit,
                 )
             )

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -876,10 +876,14 @@ def provision_job(
 
     try:
         executor.provision(
-            input_civs=job.inputs.prefetch_related(
-                "interface", "image__files"
-            ).all(),
-            input_prefixes=job.input_prefixes,
+            task_specs=[
+                executor.build_inference_task_spec(
+                    input_civs=job.inputs.prefetch_related(
+                        "interface", "image__files"
+                    ).all(),
+                    input_prefixes=job.input_prefixes,
+                )
+            ]
         )
     except ComponentException as error:
         job.update_status(

--- a/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
@@ -235,7 +235,9 @@ def test_invocation_json(settings):
                 "RemoteDebugConfig": {"EnableRemoteDebug": False},
             },
         )
-        executor.provision(input_civs=[], input_prefixes={})
+        executor.provision(
+            task_specs=[executor.build_inference_task_spec(input_civs=[])]
+        )
         executor.execute()  # Required to validate expected_params in the stubber
 
     with io.BytesIO() as fileobj:

--- a/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
@@ -101,6 +101,7 @@ def test_instance_type_incompatible(memory_limit, requires_gpu_type):
     (
         ("A", "job", "algorithms"),
         ("E", "evaluation", "evaluation"),
+        ("B", "batchjob", "evaluation"),
     ),
 )
 def test_get_job_params_match(key, model_name, app_label, settings):

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -794,11 +794,13 @@ def test_multiple_provisioning_tasks_build_one_inference_task_each():
             InferenceTaskSpec(
                 pk="test-test-1234",
                 input_civs=[first_civ],
+                input_prefixes={},
                 output_prefix=first_prefix,
             ),
             InferenceTaskSpec(
                 pk="test-test-5678",
                 input_civs=[second_civ],
+                input_prefixes={},
                 output_prefix=second_prefix,
             ),
         ]
@@ -860,6 +862,7 @@ def test_relative_paths_use_task_output_prefix():
             InferenceTaskSpec(
                 pk="test-test-1234",
                 input_civs=[civ],
+                input_prefixes={},
                 output_prefix=output_prefix,
             )
         ]

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -149,7 +149,13 @@ def test_inputs_json(settings):
         2, interface__kind=InterfaceKindChoices.ANY
     )
 
-    executor.provision(input_civs=[civ1, civ2], input_prefixes={})
+    executor.provision(
+        task_specs=[
+            executor.build_inference_task_spec(
+                input_civs=[civ1, civ2],
+            )
+        ]
+    )
 
     with io.BytesIO() as fileobj:
         executor._s3_client.download_fileobj(
@@ -267,19 +273,23 @@ def test_invocation_json(settings):
     prefixed_value_civ = value_interface.create_instance(value="foo")
 
     executor.provision(
-        input_civs=[
-            image_civ,
-            file_civ,
-            value_civ,
-            prefixed_image_civ,
-            prefixed_file_civ,
-            prefixed_value_civ,
-        ],
-        input_prefixes={
-            str(prefixed_image_civ.pk): "prefix/1",
-            str(prefixed_file_civ.pk): "prefix/2",
-            str(prefixed_value_civ.pk): "prefix/3",
-        },
+        task_specs=[
+            executor.build_inference_task_spec(
+                input_civs=[
+                    image_civ,
+                    file_civ,
+                    value_civ,
+                    prefixed_image_civ,
+                    prefixed_file_civ,
+                    prefixed_value_civ,
+                ],
+                input_prefixes={
+                    str(prefixed_image_civ.pk): "prefix/1",
+                    str(prefixed_file_civ.pk): "prefix/2",
+                    str(prefixed_value_civ.pk): "prefix/3",
+                },
+            )
+        ]
     )
 
     response = executor._s3_client.list_objects_v2(
@@ -784,13 +794,11 @@ def test_multiple_provisioning_tasks_build_one_inference_task_each():
             InferenceTaskSpec(
                 pk="test-test-1234",
                 input_civs=[first_civ],
-                input_prefixes={},
                 output_prefix=first_prefix,
             ),
             InferenceTaskSpec(
                 pk="test-test-5678",
                 input_civs=[second_civ],
-                input_prefixes={},
                 output_prefix=second_prefix,
             ),
         ]
@@ -852,7 +860,6 @@ def test_relative_paths_use_task_output_prefix():
             InferenceTaskSpec(
                 pk="test-test-1234",
                 input_civs=[civ],
-                input_prefixes={},
                 output_prefix=output_prefix,
             )
         ]
@@ -890,7 +897,17 @@ def test_provision_batch_job(settings):
 
     executor = IOCopyExecutor(**batch_job.executor_kwargs)
 
-    executor.provision_batch_job(batch_job=batch_job)
+    executor.provision(
+        task_specs=[
+            executor.build_inference_task_spec(
+                input_civs=task.inputs.all(),
+                task_pk=str(task.pk),
+            )
+            for task in batch_job.tasks.prefetch_related(
+                "inputs__interface", "inputs__image__files"
+            ).all()
+        ]
+    )
 
     first_prefix = executor._output_prefix_for_task(task_pk=str(first_task.pk))
     second_prefix = executor._output_prefix_for_task(

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -20,6 +20,7 @@ from grandchallenge.components.backends.base import (
     ASYNC_CONCURRENCY,
     Executor,
     InferenceResult,
+    ProvisioningTask,
     RuntimeSetupResult,
     s3_stream_response,
 )
@@ -40,6 +41,10 @@ from tests.components_tests.factories import (
     ComponentInterfaceValueFactory,
 )
 from tests.components_tests.resources.backends import IOCopyExecutor
+from tests.evaluation_tests.factories import (
+    BatchJobFactory,
+    BatchJobTaskFactory,
+)
 from tests.factories import ImageFactory, ImageFileFactory
 
 
@@ -508,16 +513,22 @@ def test_dicom_get_provisioning_tasks():
     )
 
     tasks = executor._get_provisioning_tasks(
-        input_civs=[
-            panimage_civ,
-            dicom_civ,
-            prefixed_panimage_civ,
-            prefixed_dicom_civ,
-        ],
-        input_prefixes={
-            str(prefixed_panimage_civ.pk): "prefix/1",
-            str(prefixed_dicom_civ.pk): "prefix/2",
-        },
+        tasks=[
+            ProvisioningTask(
+                pk=executor._job_id,
+                input_civs=[
+                    panimage_civ,
+                    dicom_civ,
+                    prefixed_panimage_civ,
+                    prefixed_dicom_civ,
+                ],
+                input_prefixes={
+                    str(prefixed_panimage_civ.pk): "prefix/1",
+                    str(prefixed_dicom_civ.pk): "prefix/2",
+                },
+                output_prefix=executor._io_prefix,
+            )
+        ]
     )
 
     normalized_tasks = [normalize_partial(t) for t in tasks]
@@ -726,13 +737,197 @@ def test_dodgy_sop_instance_uid():
 
     with pytest.raises(SuspiciousFileOperation) as exec_info:
         executor._get_provisioning_tasks(
-            input_civs=[dicom_civ], input_prefixes={}
+            tasks=[
+                ProvisioningTask(
+                    pk=executor._job_id,
+                    input_civs=[dicom_civ],
+                    input_prefixes={},
+                    output_prefix=executor._io_prefix,
+                )
+            ]
         )
 
     assert (
         "images/fds.dcm) is located outside of the base path component"
         in str(exec_info.value)
     )
+
+
+@pytest.mark.django_db
+def test_multiple_provisioning_tasks_build_one_inference_task_each():
+    job_pk = uuid4()
+
+    executor = IOCopyExecutor(
+        job_id=f"test-test-{job_pk}",
+        exec_image_repo_tag="test",
+        memory_limit=4,
+        time_limit=100,
+        requires_gpu_type=GPUTypeChoices.NO_GPU,
+        use_warm_pool=False,
+        signing_key=b"",
+        api_method=APIMethodChoices.EXEC,
+    )
+
+    value_interface = ComponentInterfaceFactory(
+        kind=InterfaceKindChoices.ANY,
+        relative_path="value.json",
+        store_in_database=True,
+    )
+    first_civ = value_interface.create_instance(value="first")
+    second_civ = value_interface.create_instance(value="second")
+
+    first_prefix = executor._output_prefix_for_task(task_pk="1234")
+    second_prefix = executor._output_prefix_for_task(task_pk="5678")
+
+    tasks = executor._get_provisioning_tasks(
+        tasks=[
+            ProvisioningTask(
+                pk="test-test-1234",
+                input_civs=[first_civ],
+                input_prefixes={},
+                output_prefix=first_prefix,
+            ),
+            ProvisioningTask(
+                pk="test-test-5678",
+                input_civs=[second_civ],
+                input_prefixes={},
+                output_prefix=second_prefix,
+            ),
+        ]
+    )
+
+    normalized_tasks = [normalize_partial(t) for t in tasks]
+
+    invocation_task = normalized_tasks[-1]
+    assert invocation_task["func"] == "s3_upload_content"
+    assert (
+        invocation_task["key"]
+        == f"/invocations/test/test/{job_pk}/invocation.json"
+    )
+
+    inference_tasks = invocation_task["content"]
+    assert len(inference_tasks) == 2
+
+    assert inference_tasks[0]["pk"] == "test-test-1234"
+    assert inference_tasks[0]["output_prefix"] == first_prefix
+    assert {i["relative_path"] for i in inference_tasks[0]["inputs"]} == {
+        "value.json",
+        "inputs.json",
+    }
+
+    assert inference_tasks[1]["pk"] == "test-test-5678"
+    assert inference_tasks[1]["output_prefix"] == second_prefix
+    assert {i["relative_path"] for i in inference_tasks[1]["inputs"]} == {
+        "value.json",
+        "inputs.json",
+    }
+
+
+@pytest.mark.django_db
+def test_relative_paths_use_task_output_prefix():
+    job_pk = uuid4()
+
+    executor = IOCopyExecutor(
+        job_id=f"test-test-{job_pk}",
+        exec_image_repo_tag="test",
+        memory_limit=4,
+        time_limit=100,
+        requires_gpu_type=GPUTypeChoices.NO_GPU,
+        use_warm_pool=False,
+        signing_key=b"",
+        api_method=APIMethodChoices.EXEC,
+    )
+
+    value_interface = ComponentInterfaceFactory(
+        kind=InterfaceKindChoices.ANY,
+        relative_path="value.json",
+        store_in_database=True,
+    )
+    civ = value_interface.create_instance(value="foo")
+
+    output_prefix = executor._output_prefix_for_task(task_pk="1234")
+
+    tasks = executor._get_provisioning_tasks(
+        tasks=[
+            ProvisioningTask(
+                pk="test-test-1234",
+                input_civs=[civ],
+                input_prefixes={},
+                output_prefix=output_prefix,
+            )
+        ]
+    )
+
+    normalized_tasks = [normalize_partial(t) for t in tasks]
+
+    value_task = normalized_tasks[0]
+    assert value_task["func"] == "s3_upload_content"
+    assert value_task["key"] == f"{output_prefix}/value.json"
+
+    inference_task = normalized_tasks[-1]["content"][0]
+    value_input = next(
+        i
+        for i in inference_task["inputs"]
+        if i["relative_path"] == "value.json"
+    )
+    assert value_input["bucket_key"] == f"{output_prefix}/value.json"
+
+
+@pytest.mark.django_db
+def test_provision_batch_job(settings):
+    batch_job = BatchJobFactory()
+
+    str_interface = ComponentInterfaceFactory(
+        kind=InterfaceKindChoices.STRING,
+        relative_path="string.json",
+        store_in_database=True,
+    )
+
+    first_task = BatchJobTaskFactory(batch_job=batch_job)
+    first_task.inputs.add(str_interface.create_instance(value="first"))
+    second_task = BatchJobTaskFactory(batch_job=batch_job)
+    second_task.inputs.add(str_interface.create_instance(value="second"))
+
+    executor = IOCopyExecutor(**batch_job.executor_kwargs)
+
+    executor.provision_batch_job(batch_job=batch_job)
+
+    first_prefix = executor._output_prefix_for_task(task_pk=str(first_task.pk))
+    second_prefix = executor._output_prefix_for_task(
+        task_pk=str(second_task.pk)
+    )
+
+    with io.BytesIO() as fileobj:
+        executor._s3_client.download_fileobj(
+            Fileobj=fileobj,
+            Bucket=settings.COMPONENTS_INPUT_BUCKET_NAME,
+            Key=executor._invocation_key,
+        )
+        fileobj.seek(0)
+        invocation = json.loads(fileobj.read().decode("utf-8"))
+
+    assert len(invocation) == 2
+
+    inference_tasks_by_prefix = {
+        inference_task["output_prefix"]: inference_task
+        for inference_task in invocation
+    }
+    assert set(inference_tasks_by_prefix) == {first_prefix, second_prefix}
+
+    for prefix in (first_prefix, second_prefix):
+        inference_task = inference_tasks_by_prefix[prefix]
+        assert {i["relative_path"] for i in inference_task["inputs"]} == {
+            "string.json",
+            "inputs.json",
+        }
+        assert (
+            next(
+                i
+                for i in inference_task["inputs"]
+                if i["relative_path"] == "string.json"
+            )["bucket_key"]
+            == f"{prefix}/string.json"
+        )
 
 
 def test_signing_key_env_set():

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -20,7 +20,7 @@ from grandchallenge.components.backends.base import (
     ASYNC_CONCURRENCY,
     Executor,
     InferenceResult,
-    ProvisioningTask,
+    InferenceTaskSpec,
     RuntimeSetupResult,
     s3_stream_response,
 )
@@ -513,8 +513,8 @@ def test_dicom_get_provisioning_tasks():
     )
 
     tasks = executor._get_provisioning_tasks(
-        tasks=[
-            ProvisioningTask(
+        task_specs=[
+            InferenceTaskSpec(
                 pk=executor._job_id,
                 input_civs=[
                     panimage_civ,
@@ -737,8 +737,8 @@ def test_dodgy_sop_instance_uid():
 
     with pytest.raises(SuspiciousFileOperation) as exec_info:
         executor._get_provisioning_tasks(
-            tasks=[
-                ProvisioningTask(
+            task_specs=[
+                InferenceTaskSpec(
                     pk=executor._job_id,
                     input_civs=[dicom_civ],
                     input_prefixes={},
@@ -780,14 +780,14 @@ def test_multiple_provisioning_tasks_build_one_inference_task_each():
     second_prefix = executor._output_prefix_for_task(task_pk="5678")
 
     tasks = executor._get_provisioning_tasks(
-        tasks=[
-            ProvisioningTask(
+        task_specs=[
+            InferenceTaskSpec(
                 pk="test-test-1234",
                 input_civs=[first_civ],
                 input_prefixes={},
                 output_prefix=first_prefix,
             ),
-            ProvisioningTask(
+            InferenceTaskSpec(
                 pk="test-test-5678",
                 input_civs=[second_civ],
                 input_prefixes={},
@@ -848,8 +848,8 @@ def test_relative_paths_use_task_output_prefix():
     output_prefix = executor._output_prefix_for_task(task_pk="1234")
 
     tasks = executor._get_provisioning_tasks(
-        tasks=[
-            ProvisioningTask(
+        task_specs=[
+            InferenceTaskSpec(
                 pk="test-test-1234",
                 input_civs=[civ],
                 input_prefixes={},


### PR DESCRIPTION
This enables the executor to provision multiple `InferenceTask`s and adds a separate provisioning entry point for batch jobs. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/374

This PR has been implemented iteratively with kiro, all code has been pre-reviewed by me.